### PR TITLE
chore(.github/workflows/release): checks if any release has been created.

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,7 +25,7 @@ jobs:
   publish:
     name: "Publish"
     needs: [release]
-    if: ${{needs.release.outputs.releases_created}}
+    if: ${{needs.release.outputs.releases_created == 'true'}}
     uses: linc-technologies/.github/.github/workflows/ember_publish.yml@main
     secrets:
       npm_token: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
Makes sure we only publish on a release being created.